### PR TITLE
Added 15 Replay-Test cases.

### DIFF
--- a/src/test/resources/unlogged/org.unlogged.springwebfluxdemo.controller.FluxOpsController.json
+++ b/src/test/resources/unlogged/org.unlogged.springwebfluxdemo.controller.FluxOpsController.json
@@ -8,18 +8,18 @@
           "subAssertions" : [ ],
           "expression" : "SELF",
           "expectedValue" : "\"stringInput\"",
-          "id" : "e1fc37aa-cd17-432b-adf7-3e1e8df37e9d",
+          "id" : "385e4918-ebad-47d6-a9e2-2b309e3c829d",
           "assertionType" : "EQUAL",
           "key" : "/"
         } ],
         "expression" : "SELF",
         "expectedValue" : null,
-        "id" : "997e4e45-8d9f-48ee-8454-372755d5a9b4",
+        "id" : "e554fb71-8680-4aee-b73c-b8ea56bc0b08",
         "assertionType" : "ALLOF",
         "key" : null
       },
-      "candidateId" : "d629c18d-0ae0-4844-84b4-1a53d9523df1",
-      "name" : "getFluxString saved on 2024-03-29 11:14",
+      "candidateId" : "3b8c6e47-f04c-443b-be17-943a4b8d837a",
+      "name" : "getFluxString_knownAssertionFailure",
       "description" : null,
       "methodArguments" : [ ],
       "returnValue" : "\"stringInput\"",
@@ -30,7 +30,7 @@
         "timestamp" : 15279560038666,
         "candidateStatus" : "NA"
       },
-      "sessionIdentifier" : 2114279867,
+      "sessionIdentifier" : -1439367195,
       "probSerializedValue" : "InN0cmluZ0lucHV0Ig==",
       "mockIds" : [ ],
       "exception" : false,
@@ -38,7 +38,284 @@
         "name" : "getFluxString",
         "signature" : "()Lreactor/core/publisher/Flux<Ljava/lang/String;>;",
         "className" : "org.unlogged.springwebfluxdemo.controller.FluxOpsController",
-        "methodHash" : -1504998540
+        "methodHash" : 0
+      }
+    } ],
+    "org.unlogged.springwebfluxdemo.controller.FluxOpsController#combineStreams#()Ljava/util/List<Ljava/lang/String;>;" : [ {
+      "lineNumbers" : [ 148, 149, 150, 151, 152, 154, 156 ],
+      "testAssertions" : {
+        "subAssertions" : [ {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "\"First Flux: 2, Second Flux: 0\"",
+          "id" : "d95bc092-f246-4c62-b0eb-b710568b5ca6",
+          "assertionType" : "EQUAL",
+          "key" : "/0"
+        }, {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "\"First Flux: 4, Second Flux: 1\"",
+          "id" : "aa1a6c4f-328c-4f20-b4c3-f5b19cfeb41d",
+          "assertionType" : "EQUAL",
+          "key" : "/1"
+        }, {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "\"First Flux: 6, Second Flux: 2\"",
+          "id" : "70a59cf4-9b95-42ba-9075-7eb0ff993474",
+          "assertionType" : "EQUAL",
+          "key" : "/2"
+        }, {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "\"First Flux: 8, Second Flux: 3\"",
+          "id" : "bc3410a1-98ab-4280-88cf-19c0776467ef",
+          "assertionType" : "EQUAL",
+          "key" : "/3"
+        } ],
+        "expression" : "SELF",
+        "expectedValue" : "true",
+        "id" : "4535e305-3354-49a2-bc9b-5ffe64b67c0b",
+        "assertionType" : "ALLOF",
+        "key" : "/"
+      },
+      "candidateId" : "5f75d26a-95f7-4f98-bd2d-e20557d78933",
+      "name" : "combineStreams_happyPath",
+      "description" : null,
+      "methodArguments" : [ ],
+      "returnValue" : "[\"First Flux: 2, Second Flux: 0\",\"First Flux: 4, Second Flux: 1\",\"First Flux: 6, Second Flux: 2\",\"First Flux: 8, Second Flux: 3\"]",
+      "returnValueClassname" : "java.util.List",
+      "metadata" : {
+        "recordedBy" : "akshatjain",
+        "hostMachineName" : "akshatjain",
+        "timestamp" : 13887230752583,
+        "candidateStatus" : "NA"
+      },
+      "sessionIdentifier" : 255507766,
+      "probSerializedValue" : "WyJGaXJzdCBGbHV4OiAyLCBTZWNvbmQgRmx1eDogMCIsIkZpcnN0IEZsdXg6IDQsIFNlY29uZCBGbHV4OiAxIiwiRmlyc3QgRmx1eDogNiwgU2Vjb25kIEZsdXg6IDIiLCJGaXJzdCBGbHV4OiA4LCBTZWNvbmQgRmx1eDogMyJd",
+      "mockIds" : [ ],
+      "exception" : false,
+      "method" : {
+        "name" : "combineStreams",
+        "signature" : "()Ljava/util/List<Ljava/lang/String;>;",
+        "className" : "org.unlogged.springwebfluxdemo.controller.FluxOpsController",
+        "methodHash" : 0
+      }
+    } ],
+    "org.unlogged.springwebfluxdemo.controller.FluxOpsController#fluxListSubscribe#()Ljava/util/List<Ljava/lang/Integer;>;" : [ {
+      "lineNumbers" : [ 22, 23, 24, 53 ],
+      "testAssertions" : {
+        "subAssertions" : [ {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "50",
+          "id" : "c523fc86-69bf-4b3f-bcb6-32dfd54ba02e",
+          "assertionType" : "EQUAL",
+          "key" : "/0"
+        }, {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "100",
+          "id" : "8b4411af-007d-4646-ab3d-896b891ba30f",
+          "assertionType" : "EQUAL",
+          "key" : "/1"
+        }, {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "150",
+          "id" : "4891623d-70ea-413c-8780-9c12d0531dbf",
+          "assertionType" : "EQUAL",
+          "key" : "/2"
+        }, {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "200",
+          "id" : "dd536c28-9f0b-48f8-bdbe-15f3b09da1eb",
+          "assertionType" : "EQUAL",
+          "key" : "/3"
+        } ],
+        "expression" : "SELF",
+        "expectedValue" : "true",
+        "id" : "720a5cd4-6776-4114-81b3-fc0f88e9bfa6",
+        "assertionType" : "ALLOF",
+        "key" : "/"
+      },
+      "candidateId" : "4675c096-1423-4451-a83b-1d1e9dfe051e",
+      "name" : "fluxListSubscribe_happyPath",
+      "description" : null,
+      "methodArguments" : [ ],
+      "returnValue" : "[50,100,150,200]",
+      "returnValueClassname" : "java.util.List",
+      "metadata" : {
+        "recordedBy" : "akshatjain",
+        "hostMachineName" : "akshatjain",
+        "timestamp" : 14285482084125,
+        "candidateStatus" : "NA"
+      },
+      "sessionIdentifier" : -2133239595,
+      "probSerializedValue" : "WzUwLDEwMCwxNTAsMjAwXQ==",
+      "mockIds" : [ ],
+      "exception" : false,
+      "method" : {
+        "name" : "fluxListSubscribe",
+        "signature" : "()Ljava/util/List<Ljava/lang/Integer;>;",
+        "className" : "org.unlogged.springwebfluxdemo.controller.FluxOpsController",
+        "methodHash" : -78710267
+      }
+    } ],
+    "org.unlogged.springwebfluxdemo.controller.FluxOpsController#fluxThrottling#()I" : [ {
+      "lineNumbers" : [ 83, 84, 91, 92, 93, 94, 95 ],
+      "testAssertions" : {
+        "subAssertions" : [ ],
+        "expression" : "SELF",
+        "expectedValue" : null,
+        "id" : "c5e9cd9f-e552-44ba-b3ab-2f177a98e6c1",
+        "assertionType" : "ALLOF",
+        "key" : null
+      },
+      "candidateId" : "b85c1258-ffa9-4cdd-91b8-9e0e75933fbf",
+      "name" : "fluxThrottling_happyPath",
+      "description" : null,
+      "methodArguments" : [ ],
+      "returnValue" : "0",
+      "returnValueClassname" : "I",
+      "metadata" : {
+        "recordedBy" : "akshatjain",
+        "hostMachineName" : "akshatjain",
+        "timestamp" : 14210983710333,
+        "candidateStatus" : "NA"
+      },
+      "sessionIdentifier" : 1274792007,
+      "probSerializedValue" : "",
+      "mockIds" : [ ],
+      "exception" : false,
+      "method" : {
+        "name" : "fluxThrottling",
+        "signature" : "()I",
+        "className" : "org.unlogged.springwebfluxdemo.controller.FluxOpsController",
+        "methodHash" : 18705804
+      }
+    } ],
+    "org.unlogged.springwebfluxdemo.controller.FluxOpsController#concurrent#()Ljava/util/List<Ljava/lang/Integer;>;" : [ {
+      "lineNumbers" : [ 100, 101, 102, 103, 104, 105, 107, 108 ],
+      "testAssertions" : {
+        "subAssertions" : [ {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "2",
+          "id" : "831a7414-aaf7-42d8-848b-8aa737fe42f5",
+          "assertionType" : "EQUAL",
+          "key" : "/0"
+        }, {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "4",
+          "id" : "bdb2d8ac-0c00-4c93-9c37-b05c11d2b8a4",
+          "assertionType" : "EQUAL",
+          "key" : "/1"
+        }, {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "6",
+          "id" : "ba8fbfb4-26bf-4d61-83b7-4ce4cf1eae66",
+          "assertionType" : "EQUAL",
+          "key" : "/2"
+        }, {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "8",
+          "id" : "0220bb7c-d688-4920-ac12-382ec6afc93f",
+          "assertionType" : "EQUAL",
+          "key" : "/3"
+        } ],
+        "expression" : "SELF",
+        "expectedValue" : "true",
+        "id" : "4d210849-a333-42a0-a577-17482fadceee",
+        "assertionType" : "ALLOF",
+        "key" : "/"
+      },
+      "candidateId" : "a4256c78-7ed1-4ff1-8b82-b182b61240e4",
+      "name" : "concurrent_happyPath",
+      "description" : null,
+      "methodArguments" : [ ],
+      "returnValue" : "[2,4,6,8]",
+      "returnValueClassname" : "java.util.List",
+      "metadata" : {
+        "recordedBy" : "akshatjain",
+        "hostMachineName" : "akshatjain",
+        "timestamp" : 14201315251458,
+        "candidateStatus" : "NA"
+      },
+      "sessionIdentifier" : 1559491002,
+      "probSerializedValue" : "WzIsNCw2LDhd",
+      "mockIds" : [ ],
+      "exception" : false,
+      "method" : {
+        "name" : "concurrent",
+        "signature" : "()Ljava/util/List<Ljava/lang/Integer;>;",
+        "className" : "org.unlogged.springwebfluxdemo.controller.FluxOpsController",
+        "methodHash" : 815895634
+      }
+    } ],
+    "org.unlogged.springwebfluxdemo.controller.FluxOpsController#backPressure1#()Ljava/util/List<Ljava/lang/Integer;>;" : [ {
+      "lineNumbers" : [ 113, 114, 115, 116, 143 ],
+      "testAssertions" : {
+        "subAssertions" : [ {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "1",
+          "id" : "0ab39294-6d6b-4fb1-9ae7-1fe7e9422429",
+          "assertionType" : "EQUAL",
+          "key" : "/0"
+        }, {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "2",
+          "id" : "42304258-f3e2-4acf-bf80-24fc8096df80",
+          "assertionType" : "EQUAL",
+          "key" : "/1"
+        }, {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "3",
+          "id" : "140c669b-9f6d-4cc8-999a-d40c13483df3",
+          "assertionType" : "EQUAL",
+          "key" : "/2"
+        }, {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "4",
+          "id" : "7177eb30-62ac-4481-bc40-d3062001fe7d",
+          "assertionType" : "EQUAL",
+          "key" : "/3"
+        } ],
+        "expression" : "SELF",
+        "expectedValue" : "true",
+        "id" : "02eb255a-557d-443f-9d09-20f9c7e3146d",
+        "assertionType" : "ALLOF",
+        "key" : "/"
+      },
+      "candidateId" : "73272d68-7079-4f09-a94a-ddb99b6a4e43",
+      "name" : "backPressure1_happyPath",
+      "description" : null,
+      "methodArguments" : [ ],
+      "returnValue" : "[1,2,3,4]",
+      "returnValueClassname" : "java.util.List",
+      "metadata" : {
+        "recordedBy" : "akshatjain",
+        "hostMachineName" : "akshatjain",
+        "timestamp" : 14189900120333,
+        "candidateStatus" : "NA"
+      },
+      "sessionIdentifier" : -1366923696,
+      "probSerializedValue" : "WzEsMiwzLDRd",
+      "mockIds" : [ ],
+      "exception" : false,
+      "method" : {
+        "name" : "backPressure1",
+        "signature" : "()Ljava/util/List<Ljava/lang/Integer;>;",
+        "className" : "org.unlogged.springwebfluxdemo.controller.FluxOpsController",
+        "methodHash" : 1581881271
       }
     } ]
   },

--- a/src/test/resources/unlogged/org.unlogged.springwebfluxdemo.controller.ReactorSchedulerOpsController.json
+++ b/src/test/resources/unlogged/org.unlogged.springwebfluxdemo.controller.ReactorSchedulerOpsController.json
@@ -1,0 +1,458 @@
+{
+  "classname" : "org.unlogged.springwebfluxdemo.controller.ReactorSchedulerOpsController",
+  "storedCandidateMap" : {
+    "org.unlogged.springwebfluxdemo.controller.ReactorSchedulerOpsController#boundedElasticScheduler#()Ljava/lang/String;" : [ {
+      "lineNumbers" : [ 33, 34, 35, 36, 37, 38 ],
+      "testAssertions" : {
+        "subAssertions" : [ {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "\"action\"",
+          "id" : "0999e338-6209-4667-947d-081bbac67c05",
+          "assertionType" : "EQUAL",
+          "key" : "/"
+        } ],
+        "expression" : "SELF",
+        "expectedValue" : null,
+        "id" : "aaa134d5-566d-4735-82aa-dc12de917924",
+        "assertionType" : "ALLOF",
+        "key" : null
+      },
+      "candidateId" : "110a81d8-01fc-461d-bd44-3ec89aed39c9",
+      "name" : "boundedElasticScheduler_happyPath",
+      "description" : null,
+      "methodArguments" : [ ],
+      "returnValue" : "\"action\"",
+      "returnValueClassname" : "java.lang.String",
+      "metadata" : {
+        "recordedBy" : "akshatjain",
+        "hostMachineName" : "akshatjain",
+        "timestamp" : 18830410124750,
+        "candidateStatus" : "NA"
+      },
+      "sessionIdentifier" : 1066749450,
+      "probSerializedValue" : "ImFjdGlvbiI=",
+      "mockIds" : [ ],
+      "exception" : false,
+      "method" : {
+        "name" : "boundedElasticScheduler",
+        "signature" : "()Ljava/lang/String;",
+        "className" : "org.unlogged.springwebfluxdemo.controller.ReactorSchedulerOpsController",
+        "methodHash" : 0
+      }
+    } ],
+    "org.unlogged.springwebfluxdemo.controller.ReactorSchedulerOpsController#immediateScheduler#()Ljava/lang/String;" : [ {
+      "lineNumbers" : [ 24, 25, 26, 27, 28 ],
+      "testAssertions" : {
+        "subAssertions" : [ {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "\"action\"",
+          "id" : "f26935e4-8694-4e24-88c1-46138ab462dc",
+          "assertionType" : "EQUAL",
+          "key" : "/"
+        } ],
+        "expression" : "SELF",
+        "expectedValue" : null,
+        "id" : "950a0cca-268c-48ab-8709-91956920a98e",
+        "assertionType" : "ALLOF",
+        "key" : null
+      },
+      "candidateId" : "3ca42164-790b-4b92-9ea2-5f3aa9cf2c2b",
+      "name" : "immediateScheduler_happyPath",
+      "description" : null,
+      "methodArguments" : [ ],
+      "returnValue" : "\"action\"",
+      "returnValueClassname" : "java.lang.String",
+      "metadata" : {
+        "recordedBy" : "akshatjain",
+        "hostMachineName" : "akshatjain",
+        "timestamp" : 18812208623166,
+        "candidateStatus" : "NA"
+      },
+      "sessionIdentifier" : 876214338,
+      "probSerializedValue" : "ImFjdGlvbiI=",
+      "mockIds" : [ ],
+      "exception" : false,
+      "method" : {
+        "name" : "immediateScheduler",
+        "signature" : "()Ljava/lang/String;",
+        "className" : "org.unlogged.springwebfluxdemo.controller.ReactorSchedulerOpsController",
+        "methodHash" : 0
+      }
+    } ],
+    "org.unlogged.springwebfluxdemo.controller.ReactorSchedulerOpsController#customBEScheduler#()Ljava/lang/String;" : [ {
+      "lineNumbers" : [ 43, 44, 45, 46, 47, 48 ],
+      "testAssertions" : {
+        "subAssertions" : [ {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "\"action\"",
+          "id" : "9096ec29-e094-46de-ad55-4c3b1dc2469f",
+          "assertionType" : "EQUAL",
+          "key" : "/"
+        } ],
+        "expression" : "SELF",
+        "expectedValue" : null,
+        "id" : "8897c49b-0d7d-4f78-ad6e-ad46d21b3bff",
+        "assertionType" : "ALLOF",
+        "key" : null
+      },
+      "candidateId" : "89a5b193-f3c8-49e4-8799-be51fbbca26c",
+      "name" : "customBEScheduler_happyPath",
+      "description" : null,
+      "methodArguments" : [ ],
+      "returnValue" : "\"action\"",
+      "returnValueClassname" : "java.lang.String",
+      "metadata" : {
+        "recordedBy" : "akshatjain",
+        "hostMachineName" : "akshatjain",
+        "timestamp" : 19020481431250,
+        "candidateStatus" : "NA"
+      },
+      "sessionIdentifier" : 630398780,
+      "probSerializedValue" : "ImFjdGlvbiI=",
+      "mockIds" : [ ],
+      "exception" : false,
+      "method" : {
+        "name" : "customBEScheduler",
+        "signature" : "()Ljava/lang/String;",
+        "className" : "org.unlogged.springwebfluxdemo.controller.ReactorSchedulerOpsController",
+        "methodHash" : 0
+      }
+    } ],
+    "org.unlogged.springwebfluxdemo.controller.ReactorSchedulerOpsController#executorBasedScheduler#()Ljava/lang/String;" : [ {
+      "lineNumbers" : [ 53, 56, 57, 58, 59, 60, 61 ],
+      "testAssertions" : {
+        "subAssertions" : [ {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "\"action\"",
+          "id" : "33f30909-8cee-4be8-a18d-7fbc1ae977a9",
+          "assertionType" : "EQUAL",
+          "key" : "/"
+        } ],
+        "expression" : "SELF",
+        "expectedValue" : null,
+        "id" : "2a6ad110-30e6-453d-aa63-b092acb2d0b2",
+        "assertionType" : "ALLOF",
+        "key" : null
+      },
+      "candidateId" : "427f53d6-3c83-44f7-9539-74cb380ed3a7",
+      "name" : "executorBasedScheduler_happyPath",
+      "description" : null,
+      "methodArguments" : [ ],
+      "returnValue" : "\"action\"",
+      "returnValueClassname" : "java.lang.String",
+      "metadata" : {
+        "recordedBy" : "akshatjain",
+        "hostMachineName" : "akshatjain",
+        "timestamp" : 19027537014458,
+        "candidateStatus" : "NA"
+      },
+      "sessionIdentifier" : 1077721207,
+      "probSerializedValue" : "ImFjdGlvbiI=",
+      "mockIds" : [ ],
+      "exception" : false,
+      "method" : {
+        "name" : "executorBasedScheduler",
+        "signature" : "()Ljava/lang/String;",
+        "className" : "org.unlogged.springwebfluxdemo.controller.ReactorSchedulerOpsController",
+        "methodHash" : 0
+      }
+    } ],
+    "org.unlogged.springwebfluxdemo.controller.ReactorSchedulerOpsController#parallelExecutor#()Ljava/lang/String;" : [ {
+      "lineNumbers" : [ 66, 67, 68, 69, 70, 71 ],
+      "testAssertions" : {
+        "subAssertions" : [ {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "\"action\"",
+          "id" : "4287d3ac-77b4-440c-891f-7b670e3e6343",
+          "assertionType" : "EQUAL",
+          "key" : "/"
+        } ],
+        "expression" : "SELF",
+        "expectedValue" : null,
+        "id" : "b278b2de-a063-43ff-8452-b6f4547a7aac",
+        "assertionType" : "ALLOF",
+        "key" : null
+      },
+      "candidateId" : "4cb310f5-a966-4b04-af5b-b80edf455b48",
+      "name" : "parallelExecutor_happyPath",
+      "description" : null,
+      "methodArguments" : [ ],
+      "returnValue" : "\"action\"",
+      "returnValueClassname" : "java.lang.String",
+      "metadata" : {
+        "recordedBy" : "akshatjain",
+        "hostMachineName" : "akshatjain",
+        "timestamp" : 19037948665166,
+        "candidateStatus" : "NA"
+      },
+      "sessionIdentifier" : 1519422479,
+      "probSerializedValue" : "ImFjdGlvbiI=",
+      "mockIds" : [ ],
+      "exception" : false,
+      "method" : {
+        "name" : "parallelExecutor",
+        "signature" : "()Ljava/lang/String;",
+        "className" : "org.unlogged.springwebfluxdemo.controller.ReactorSchedulerOpsController",
+        "methodHash" : 0
+      }
+    } ],
+    "org.unlogged.springwebfluxdemo.controller.ReactorSchedulerOpsController#singleScheduler#()Ljava/lang/String;" : [ {
+      "lineNumbers" : [ 76, 77, 78, 79, 80, 81 ],
+      "testAssertions" : {
+        "subAssertions" : [ {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "\"action\"",
+          "id" : "0c92f197-c8a0-416f-9f6a-6c32f5accd2a",
+          "assertionType" : "EQUAL",
+          "key" : "/"
+        } ],
+        "expression" : "SELF",
+        "expectedValue" : null,
+        "id" : "5f8bc559-5cb2-46be-8461-d5eb2bc47f02",
+        "assertionType" : "ALLOF",
+        "key" : null
+      },
+      "candidateId" : "723992fa-59dd-4eeb-89bc-667810f05d05",
+      "name" : "singleScheduler_happyPath",
+      "description" : null,
+      "methodArguments" : [ ],
+      "returnValue" : "\"action\"",
+      "returnValueClassname" : "java.lang.String",
+      "metadata" : {
+        "recordedBy" : "akshatjain",
+        "hostMachineName" : "akshatjain",
+        "timestamp" : 19043423731708,
+        "candidateStatus" : "NA"
+      },
+      "sessionIdentifier" : 1472649561,
+      "probSerializedValue" : "ImFjdGlvbiI=",
+      "mockIds" : [ ],
+      "exception" : false,
+      "method" : {
+        "name" : "singleScheduler",
+        "signature" : "()Ljava/lang/String;",
+        "className" : "org.unlogged.springwebfluxdemo.controller.ReactorSchedulerOpsController",
+        "methodHash" : 0
+      }
+    } ],
+    "org.unlogged.springwebfluxdemo.controller.ReactorSchedulerOpsController#scheduleSubscribeOn#()Ljava/util/List<Ljava/lang/String;>;" : [ {
+      "lineNumbers" : [ 86, 87, 88, 89, 90, 94, 95 ],
+      "testAssertions" : {
+        "subAssertions" : [ {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "\"url 1  2\"",
+          "id" : "122cb3c5-12be-46b7-82fa-1a86ec87ee47",
+          "assertionType" : "EQUAL",
+          "key" : "/0"
+        }, {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "\"url xy\"",
+          "id" : "8447834a-4b53-4f07-9fcc-65f317e6b6fb",
+          "assertionType" : "EQUAL",
+          "key" : "/1"
+        }, {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "\"urlz\"",
+          "id" : "9f395812-fc7d-49f0-ad72-ee675db2f37b",
+          "assertionType" : "EQUAL",
+          "key" : "/2"
+        } ],
+        "expression" : "SELF",
+        "expectedValue" : "true",
+        "id" : "14f45888-fad1-411b-bcbe-4f394327faa3",
+        "assertionType" : "ALLOF",
+        "key" : "/"
+      },
+      "candidateId" : "0c025c24-b7f2-4692-aa4e-27c2a0767b36",
+      "name" : "scheduleSubscribeOn_happyPath",
+      "description" : null,
+      "methodArguments" : [ ],
+      "returnValue" : "[\"url 1  2\",\"url xy\",\"urlz\"]",
+      "returnValueClassname" : "java.util.List",
+      "metadata" : {
+        "recordedBy" : "akshatjain",
+        "hostMachineName" : "akshatjain",
+        "timestamp" : 19087113987791,
+        "candidateStatus" : "NA"
+      },
+      "sessionIdentifier" : -1080425469,
+      "probSerializedValue" : "WyJ1cmwgMSAgMiIsInVybCB4eSIsInVybHoiXQ==",
+      "mockIds" : [ ],
+      "exception" : false,
+      "method" : {
+        "name" : "scheduleSubscribeOn",
+        "signature" : "()Ljava/util/List<Ljava/lang/String;>;",
+        "className" : "org.unlogged.springwebfluxdemo.controller.ReactorSchedulerOpsController",
+        "methodHash" : 773616771
+      }
+    } ],
+    "org.unlogged.springwebfluxdemo.controller.ReactorSchedulerOpsController#fetchUrls#(Ljava/util/List<Ljava/lang/String;>;)Lreactor/core/publisher/Flux<Ljava/lang/String;>;" : [ {
+      "lineNumbers" : [ 99, 100 ],
+      "testAssertions" : {
+        "subAssertions" : [ {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "\"[\\\"url 1  2\\\",,\\\"urlz\\\"]\"",
+          "id" : "8d8d8c0e-df7a-42ae-a430-0a466d36d991",
+          "assertionType" : "EQUAL",
+          "key" : "/"
+        } ],
+        "expression" : "SELF",
+        "expectedValue" : null,
+        "id" : "92b2d6e3-d368-42fa-b7f3-de985d61170a",
+        "assertionType" : "ALLOF",
+        "key" : null
+      },
+      "candidateId" : "83b8db4e-336c-4034-a10d-a16d5f683637",
+      "name" : "fetchUrls_knownAssertionFailure",
+      "description" : null,
+      "methodArguments" : [ "[\"url 1  2  \",\"url xy \",\"urlz\"]" ],
+      "returnValue" : "[\"url 1  2\",,\"urlz\"]",
+      "returnValueClassname" : "reactor.core.publisher.Flux",
+      "metadata" : {
+        "recordedBy" : "akshatjain",
+        "hostMachineName" : "akshatjain",
+        "timestamp" : 19087115680500,
+        "candidateStatus" : "NA"
+      },
+      "sessionIdentifier" : -1138183334,
+      "probSerializedValue" : "WyJ1cmwgMSAgMiIsLCJ1cmx6Il0=",
+      "mockIds" : [ ],
+      "exception" : false,
+      "method" : {
+        "name" : "fetchUrls",
+        "signature" : "(Ljava/util/List<Ljava/lang/String;>;)Lreactor/core/publisher/Flux<Ljava/lang/String;>;",
+        "className" : "org.unlogged.springwebfluxdemo.controller.ReactorSchedulerOpsController",
+        "methodHash" : 2134970057
+      }
+    } ],
+    "org.unlogged.springwebfluxdemo.controller.ReactorSchedulerOpsController#processUrl#(Ljava/lang/String;)Ljava/lang/String;" : [ {
+      "lineNumbers" : [ 105 ],
+      "testAssertions" : {
+        "subAssertions" : [ {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "\"url xy\"",
+          "id" : "c1ebba0a-7656-4587-8474-670c9f28bf07",
+          "assertionType" : "EQUAL",
+          "key" : "/"
+        } ],
+        "expression" : "SELF",
+        "expectedValue" : null,
+        "id" : "1f316f1b-57db-48c8-a54b-1dfdc727a807",
+        "assertionType" : "ALLOF",
+        "key" : null
+      },
+      "candidateId" : "a0035f89-239f-4190-85fe-3fd48124abc0",
+      "name" : "processUrl_happyPath",
+      "description" : null,
+      "methodArguments" : [ "\"url xy \"" ],
+      "returnValue" : "\"url xy\"",
+      "returnValueClassname" : "java.lang.String",
+      "metadata" : {
+        "recordedBy" : "akshatjain",
+        "hostMachineName" : "akshatjain",
+        "timestamp" : 19087132824625,
+        "candidateStatus" : "NA"
+      },
+      "sessionIdentifier" : 1408320616,
+      "probSerializedValue" : "InVybCB4eSI=",
+      "mockIds" : [ ],
+      "exception" : false,
+      "method" : {
+        "name" : "processUrl",
+        "signature" : "(Ljava/lang/String;)Ljava/lang/String;",
+        "className" : "org.unlogged.springwebfluxdemo.controller.ReactorSchedulerOpsController",
+        "methodHash" : 205669483
+      }
+    }, {
+      "lineNumbers" : [ 105 ],
+      "testAssertions" : {
+        "subAssertions" : [ {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "\"url 1  2\"",
+          "id" : "4941cec7-3d40-440e-9291-756618489ffb",
+          "assertionType" : "EQUAL",
+          "key" : "/"
+        } ],
+        "expression" : "SELF",
+        "expectedValue" : null,
+        "id" : "bfb4ccbf-5159-4cef-a2e4-7825022ed252",
+        "assertionType" : "ALLOF",
+        "key" : null
+      },
+      "candidateId" : "15e1c36b-8c18-4ff1-8347-52ab4cdba3c8",
+      "name" : "processUrl_happyPath",
+      "description" : null,
+      "methodArguments" : [ "\"url 1  2  \"" ],
+      "returnValue" : "\"url 1  2\"",
+      "returnValueClassname" : "java.lang.String",
+      "metadata" : {
+        "recordedBy" : "akshatjain",
+        "hostMachineName" : "akshatjain",
+        "timestamp" : 19087125002375,
+        "candidateStatus" : "NA"
+      },
+      "sessionIdentifier" : -634617997,
+      "probSerializedValue" : "InVybCAxICAyIg==",
+      "mockIds" : [ ],
+      "exception" : false,
+      "method" : {
+        "name" : "processUrl",
+        "signature" : "(Ljava/lang/String;)Ljava/lang/String;",
+        "className" : "org.unlogged.springwebfluxdemo.controller.ReactorSchedulerOpsController",
+        "methodHash" : 205669483
+      }
+    }, {
+      "lineNumbers" : [ 105 ],
+      "testAssertions" : {
+        "subAssertions" : [ {
+          "subAssertions" : [ ],
+          "expression" : "SELF",
+          "expectedValue" : "\"urlz\"",
+          "id" : "19d1d531-4a13-4a82-af0f-09b19214cb5c",
+          "assertionType" : "EQUAL",
+          "key" : "/"
+        } ],
+        "expression" : "SELF",
+        "expectedValue" : null,
+        "id" : "c0ede1fa-365d-4fa7-aa94-1b33122733dc",
+        "assertionType" : "ALLOF",
+        "key" : null
+      },
+      "candidateId" : "1c0d966a-1893-4c55-89f7-585edc4a6c01",
+      "name" : "processUrl_happyPath",
+      "description" : null,
+      "methodArguments" : [ "\"urlz\"" ],
+      "returnValue" : "\"urlz\"",
+      "returnValueClassname" : "java.lang.String",
+      "metadata" : {
+        "recordedBy" : "akshatjain",
+        "hostMachineName" : "akshatjain",
+        "timestamp" : 19087137597416,
+        "candidateStatus" : "NA"
+      },
+      "sessionIdentifier" : 966511064,
+      "probSerializedValue" : "InVybHoi",
+      "mockIds" : [ ],
+      "exception" : false,
+      "method" : {
+        "name" : "processUrl",
+        "signature" : "(Ljava/lang/String;)Ljava/lang/String;",
+        "className" : "org.unlogged.springwebfluxdemo.controller.ReactorSchedulerOpsController",
+        "methodHash" : 205669483
+      }
+    } ]
+  },
+  "declaredMockMap" : { }
+}


### PR DESCRIPTION
Added replay tests cases for:
1. ReactorSchedularOpsController: 9 replay cases
2. FluxOpsController: 6

Note: known Assertion Failures in 2 cases: getFluxString and fetchUrl