### PR TITLE
Added Cron Job, Recursive, var keyword usage cases.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <artifactId>unlogged-sdk</artifactId>
             <groupId>video.bug</groupId>
-            <version>0.6.0</version>
+            <version>0.6.1</version>
         </dependency>
         <dependency>
             <groupId>io.reactivex.rxjava3</groupId>

--- a/src/main/java/org/unlogged/springwebfluxdemo/CronConfig.java
+++ b/src/main/java/org/unlogged/springwebfluxdemo/CronConfig.java
@@ -1,0 +1,9 @@
+package org.unlogged.springwebfluxdemo;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class CronConfig {
+}

--- a/src/main/java/org/unlogged/springwebfluxdemo/controller/CronController.java
+++ b/src/main/java/org/unlogged/springwebfluxdemo/controller/CronController.java
@@ -1,0 +1,25 @@
+package org.unlogged.springwebfluxdemo.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.unlogged.springwebfluxdemo.service.CronService;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/cron")
+public class CronController {
+
+    private final CronService cronService;
+
+    @Autowired
+    public CronController(CronService cronService) {
+        this.cronService = cronService;
+    }
+
+    @GetMapping("/hello")
+    public Mono<String> cronHello() {
+        return cronService.getCount().map(count ->"Hello Cron: " + count);
+    }
+}

--- a/src/main/java/org/unlogged/springwebfluxdemo/controller/RecursiveController.java
+++ b/src/main/java/org/unlogged/springwebfluxdemo/controller/RecursiveController.java
@@ -1,0 +1,30 @@
+package org.unlogged.springwebfluxdemo.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.unlogged.springwebfluxdemo.service.RecursiveService;
+import reactor.core.publisher.Mono;
+
+@RestController
+public class RecursiveController {
+
+    private final RecursiveService recursiveService;
+
+    @Autowired
+    public  RecursiveController(RecursiveService recursiveService) {
+        this.recursiveService = recursiveService;
+    }
+
+    @RequestMapping("/factorial/{number}")
+    public Mono<Integer> factorial(@PathVariable Integer number) {
+        return recursiveService.factorial(number);
+    }
+
+    @GetMapping("/fibonacci/{n}")
+    public Mono<Long> nthFibonacci(@PathVariable int n) {
+        return recursiveService.nthFibonacci(n);
+    }
+}

--- a/src/main/java/org/unlogged/springwebfluxdemo/controller/VarKeywordController.java
+++ b/src/main/java/org/unlogged/springwebfluxdemo/controller/VarKeywordController.java
@@ -1,0 +1,87 @@
+package org.unlogged.springwebfluxdemo.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/var")
+public class VarKeywordController {
+
+    @RequestMapping("/int")
+    public Mono<Integer> getIntVar(@RequestParam int n) {
+        var a = 9;
+        a+=n;
+        return Mono.just(a);
+    }
+//Issue with float
+    @RequestMapping("/float")
+    public Mono<Float> getFloatVar(@RequestParam float n) {
+        var a = 9.0f;
+        a+=n;
+        return Mono.just(a);
+    }
+//Issue with double
+    @RequestMapping("/double")
+    public Mono<Double> getDoubleVar(@RequestParam double n) {
+        var a = 9.99;
+        a+=n;
+        return Mono.just(a);
+    }
+
+    @RequestMapping("/String")
+    public Mono<String> getStringVar(@RequestParam char n) {
+        var a = 'c';
+        var b= "ab";
+        return Mono.just(b+a+n);
+    }
+
+    @RequestMapping("/char")
+    public Mono<Character> getCharVar(@RequestParam char n) {
+        var c = n;
+        return Mono.just(c);
+    }
+
+    //Integer array
+    @RequestMapping("/array")
+    public Flux<Integer> getIntegerArrayVar(@RequestParam int n) {
+        var array = new Integer[n];
+        for (var i = 0; i < n; i++) {
+            array[i] = i + 1;
+        }
+        return Flux.fromArray(array);
+    }
+
+    // Object
+    @RequestMapping("/object")
+    public Mono<ObjectTest> getObjectVar(@RequestParam int n) {
+        var obj = new ObjectTest(n, 'a', "test", 9.99);
+        return Mono.just(obj);
+    }
+
+    // array of objects
+    @RequestMapping("/objarray")
+    public Flux<ObjectTest> getObjectArrayVar(@RequestParam int n) {
+        var array = new ObjectTest[n];
+        for (var i = 0; i < n; i++) {
+            array[i] = new ObjectTest(i+1,'a', "test", 9.99);
+        }
+        return Flux.fromArray(array);
+    }
+}
+
+class ObjectTest {
+    int a;
+    char b;
+    String c;
+    Double d;
+
+    public ObjectTest(int a, char b, String c, Double d) {
+        this.a = a;
+        this.b = b;
+        this.c = c;
+        this.d = d;
+    }
+}

--- a/src/main/java/org/unlogged/springwebfluxdemo/service/CronService.java
+++ b/src/main/java/org/unlogged/springwebfluxdemo/service/CronService.java
@@ -1,0 +1,29 @@
+package org.unlogged.springwebfluxdemo.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Service
+public class CronService {
+
+    private final AtomicInteger counter;
+
+    @Autowired
+    public CronService() {
+        this.counter = new AtomicInteger(0);
+    }
+
+    @Scheduled(cron = "0 * * ? * *")
+    public void executeTask() {
+        counter.incrementAndGet();
+        System.out.println("Task executed. Current count: " + counter.get());
+    }
+
+    public Mono<Integer> getCount() {
+        return Mono.just(counter.get());
+    }
+}

--- a/src/main/java/org/unlogged/springwebfluxdemo/service/RecursiveService.java
+++ b/src/main/java/org/unlogged/springwebfluxdemo/service/RecursiveService.java
@@ -1,0 +1,31 @@
+package org.unlogged.springwebfluxdemo.service;
+
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+public class RecursiveService {
+
+    public Mono<Integer> factorial(Integer number) {
+        if (number <= 1) {
+            return Mono.just(1);
+        } else {
+            return Mono.just(number)
+                    .flatMap(n -> factorial(n - 1))
+                    .flatMap(result -> Mono.just(number * result));
+        }
+    }
+
+    public Mono<Long> nthFibonacci(int n) {
+        return fibonacci(n);
+    }
+
+    private Mono<Long> fibonacci(int n) {
+        if (n <= 1) {
+            return Mono.just((long) n);
+        } else {
+            return Mono.zip(fibonacci(n - 1), fibonacci(n - 2), (a, b) -> a + b);
+        }
+    }
+}


### PR DESCRIPTION
**1. Added Case for Cron Job using `@Scheduled` annotation.**
Candidates successfully generating each time the cron job executes (every minute).

_Issue Observed (It is a general issue with Mono and not specifically Cron jobs):_
The output is shown in a terminal window and not as a return value.
<img width="466" alt="Screenshot 2024-06-06 at 12 37 25 PM" src="https://github.com/unloggedio/unlogged-spring-webflux-maven-demo/assets/60289128/151af74e-d5ff-407d-864a-07bb21e27a3a">

**2. Added recursive Controllers.**
_No issue observed._

**3. Added cases for var keyword usage.**

_Issues: Float and double causing issues with unlogged-sdk._

![image](https://github.com/unloggedio/unlogged-spring-webflux-maven-demo/assets/60289128/e383dd11-f088-446a-8e34-769bfb4135e9)

